### PR TITLE
Use a disk buffer to avoid many small disk writes

### DIFF
--- a/benches/mpsc_snd_rcv.rs
+++ b/benches/mpsc_snd_rcv.rs
@@ -11,7 +11,7 @@ fn bench_snd(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-        for _ in 0..1000 {
+        for _ in 0..10_000 {
             snd.send(412u64);
         }
     });
@@ -32,10 +32,10 @@ fn bench_all_snd_all_rcv(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-        for _ in 0..1000 {
+        for _ in 0..10_000 {
             snd.send(89u64);
         }
-        for _ in 0..1000 {
+        for _ in 0..10_000 {
             rcv.next().unwrap();
         }
     });

--- a/src/private.rs
+++ b/src/private.rs
@@ -3,21 +3,25 @@ use std::sync::{Arc, Mutex};
 
 #[derive(Default, Debug)]
 pub struct FsSync<T> {
-    pub small_buffer: VecDeque<T>,
-    pub max_small_buffer: usize,
+    pub max_buffer: usize,
     pub bytes_written: usize,
     pub writes_to_read: usize,
+    pub disk_writes_to_read: usize,
     pub sender_seq_num: usize,
+    pub mem_buffer: VecDeque<T>,
+    pub disk_buffer: VecDeque<T>,
 }
 
 impl<T> FsSync<T> {
     pub fn new(cap: usize) -> FsSync<T> {
         FsSync {
-            small_buffer: VecDeque::with_capacity(cap),
-            max_small_buffer: cap,
+            max_buffer: cap,
             bytes_written: 0,
             writes_to_read: 0,
+            disk_writes_to_read: 0,
             sender_seq_num: 0,
+            mem_buffer: VecDeque::with_capacity(cap),
+            disk_buffer: VecDeque::with_capacity(cap),
         }
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -2,7 +2,7 @@ use bincode::SizeLimit;
 use bincode::serde::serialize_into;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::io::Write;
+use std::io::{Write, BufWriter};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::fmt;
@@ -21,7 +21,7 @@ pub struct Sender<T> {
     name: String,
     root: PathBuf, // directory we store our queues in
     path: PathBuf, // active fp filename
-    fp: fs::File, // active fp
+    fp: BufWriter<fs::File>, // active fp
     seq_num: usize,
     max_bytes: usize,
     fs_lock: private::FSLock<T>,
@@ -83,7 +83,7 @@ impl<T> Sender<T>
                     name: name.into(),
                     root: data_dir.to_path_buf(),
                     path: log,
-                    fp: fp,
+                    fp: BufWriter::new(fp),
                     seq_num: seq_num,
                     max_bytes: max_bytes,
                     fs_lock: fs_lock,
@@ -101,66 +101,75 @@ impl<T> Sender<T>
     ///
     pub fn send(&mut self, event: T) {
         let mut syn = self.fs_lock.lock().expect("Sender fs_lock poisoned");
-        if (*syn).writes_to_read < (*syn).max_small_buffer {
-            (*syn).small_buffer.push_front(event);
-            (*syn).writes_to_read += 1;
+        let fslock = &mut (*syn);
+        fslock.writes_to_read += 1;
+        if fslock.writes_to_read < fslock.max_buffer {
+            fslock.mem_buffer.push_front(event);
         } else {
-            let mut pyld = Vec::with_capacity(64);
-            serialize_into(&mut pyld, &event, SizeLimit::Infinite).expect("could not serialize");
-            // NOTE The conversion of t.len to u32 and usize is _only_ safe when u32
-            // <= usize. That's very likely to hold true for machines--for
-            // now?--that cernan will run on. However!
-            let pyld_sz_bytes: [u8; 4] = u32tou8abe(pyld.len() as u32);
-            let mut t = vec![0, 0, 0, 0];
-            t[0] = pyld_sz_bytes[3];
-            t[1] = pyld_sz_bytes[2];
-            t[2] = pyld_sz_bytes[1];
-            t[3] = pyld_sz_bytes[0];
-            t.append(&mut pyld);
-            // If the individual sender writes enough to go over the max we mark the
-            // file read-only--which will help the receiver to decide it has hit the
-            // end of its log file--and create a new log file.
-            let bytes_written = (*syn).bytes_written + t.len();
-            if (bytes_written > self.max_bytes) || (self.seq_num != (*syn).sender_seq_num) {
-                // Once we've gone over the write limit for our current file or find
-                // that we've gotten behind the current queue file we need to seek
-                // forward to find our place in the space of queue files. We mark
-                // our current file read-only--there's some possibility that this
-                // will be done redundantly, but that's okay--and then read the
-                // current sender_seq_num to get up to date.
-                let _ = fs::metadata(&self.path).map(|p| {
-                    let mut permissions = p.permissions();
-                    permissions.set_readonly(true);
-                    let _ = fs::set_permissions(&self.path, permissions);
-                });
-                if self.seq_num != (*syn).sender_seq_num {
-                    // This thread is behind the leader. We've got to set our
-                    // current notion of seq_num forward and then open the
-                    // corresponding file.
-                    self.seq_num = (*syn).sender_seq_num;
-                } else {
-                    // This thread is the leader. We reset the sender_seq_num and
-                    // bytes written and open the next queue file. All follower
-                    // threads will hit the branch above this one.
-                    (*syn).sender_seq_num = self.seq_num.wrapping_add(1);
-                    self.seq_num = (*syn).sender_seq_num;
-                    (*syn).bytes_written = 0;
-                }
-                self.path = self.root.join(format!("{}", self.seq_num));
-                match fs::OpenOptions::new().append(true).create(true).open(&self.path) {
-                    Ok(fp) => self.fp = fp,
-                    Err(e) => panic!("FAILED TO OPEN {:?} WITH {:?}", &self.path, e),
-                }
-            }
+            fslock.disk_buffer.push_front(event);
+            if fslock.disk_buffer.len() >= fslock.max_buffer {
+                while let Some(ev) = fslock.disk_buffer.pop_front() {
+                    let mut pyld = Vec::with_capacity(64);
+                    serialize_into(&mut pyld, &ev, SizeLimit::Infinite)
+                        .expect("could not serialize");
+                    // NOTE The conversion of t.len to u32 and usize is _only_
+                    // safe when u32 <= usize. That's very likely to hold true
+                    // for machines--for now?--that cernan will run on. However!
+                    let pyld_sz_bytes: [u8; 4] = u32tou8abe(pyld.len() as u32);
+                    let mut t = vec![0, 0, 0, 0];
+                    t[0] = pyld_sz_bytes[3];
+                    t[1] = pyld_sz_bytes[2];
+                    t[2] = pyld_sz_bytes[1];
+                    t[3] = pyld_sz_bytes[0];
+                    t.append(&mut pyld);
+                    // If the individual sender writes enough to go over the max
+                    // we mark the file read-only--which will help the receiver
+                    // to decide it has hit the end of its log file--and create
+                    // a new log file.
+                    let bytes_written = fslock.bytes_written + t.len();
+                    if (bytes_written > self.max_bytes) || (self.seq_num != fslock.sender_seq_num) {
+                        // Once we've gone over the write limit for our current
+                        // file or find that we've gotten behind the current
+                        // queue file we need to seek forward to find our place
+                        // in the space of queue files. We mark our current file
+                        // read-only--there's some possibility that this will be
+                        // done redundantly, but that's okay--and then read the
+                        // current sender_seq_num to get up to date.
+                        let _ = fs::metadata(&self.path).map(|p| {
+                            let mut permissions = p.permissions();
+                            permissions.set_readonly(true);
+                            let _ = fs::set_permissions(&self.path, permissions);
+                        });
+                        if self.seq_num != fslock.sender_seq_num {
+                            // This thread is behind the leader. We've got to
+                            // set our current notion of seq_num forward and
+                            // then open the corresponding file.
+                            self.seq_num = fslock.sender_seq_num;
+                        } else {
+                            // This thread is the leader. We reset the
+                            // sender_seq_num and bytes written and open the
+                            // next queue file. All follower threads will hit
+                            // the branch above this one.
+                            fslock.sender_seq_num = self.seq_num.wrapping_add(1);
+                            self.seq_num = fslock.sender_seq_num;
+                            fslock.bytes_written = 0;
+                        }
+                        self.path = self.root.join(format!("{}", self.seq_num));
+                        match fs::OpenOptions::new().append(true).create(true).open(&self.path) {
+                            Ok(fp) => self.fp = BufWriter::new(fp),
+                            Err(e) => panic!("FAILED TO OPEN {:?} WITH {:?}", &self.path, e),
+                        }
+                    }
 
-            let fp = &mut self.fp;
-            match fp.write(&t[..]) {
-                Ok(written) => (*syn).bytes_written += written,
-                Err(e) => panic!("Write error: {}", e),
+                    let fp = &mut self.fp;
+                    match fp.write(&t[..]) {
+                        Ok(written) => fslock.bytes_written += written,
+                        Err(e) => panic!("Write error: {}", e),
+                    }
+                    fslock.disk_writes_to_read += 1;
+                }
+                self.fp.flush().expect("unable to flush");
             }
-            fp.flush().expect("unable to flush");
-            // Let the Receiver know there's more to read.
-            (*syn).writes_to_read += 1;
         }
     }
 


### PR DESCRIPTION
At the suggestion of Reddit user matthieum [here](https://www.reddit.com/r/rust/comments/5iyjop/hopper_mpsc_variant_with_unbounded_members_in/dbc7w7b/) I've introduced an additional buffer to allow hopper to avoid the many small WRITE/FLUSH pairs it used to do. It was a great suggestion! The benchmarking numbers are very promising:

    name                   control ns/iter  variable ns/iter  diff ns/iter   diff %
    bench_all_snd_all_rcv  14,121,724       1,775,434          -12,346,290  -87.43%
    bench_snd              13,889,518       1,165,738          -12,723,780  -91.61%
    bench_snd_rcv          64               60                          -4   -6.25%

Here 'control' is the WRITE/FLUSH approach previously taken and 'variable' is the new scheme.

This resolves #1 and #2 

Signed-off-by: Brian L. Troutwine <blt@postmates.com>