### PR TITLE
Update to serde 0.9, add explicit codecov.yml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/postmates/hopper"
 version = "0.1.2"
 
 [dev-dependencies]
-quickcheck = "0.3"
+quickcheck = "0.4"
 tempdir = "0.3"
 
 [dependencies]
-serde = "0.8"
-bincode = "0.6"
+serde = "0.9"
+bincode = "1.0.0-alpha1"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    # Learn more at http://docs.codecov.io/docs/codecov-yaml
+    project: true
+    changes: false
+
+    patch:
+      default:
+        target: 93%
+        threshold: 1%
+
+comment:
+  layout: "header, diff"
+  behavior: default  # update if exists else create new


### PR DESCRIPTION
Now that rust 1.15 is here we can make use of serde's custom derive
in stable. There is no longer any need for us to have the wacky build.rs
to do codegen.

We also add a codecov.yml to control the ranges of coverage considered
acceptable for this project.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>