### PR TITLE
Update bincode calls to use root definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ tempdir = "0.3"
 
 [dependencies]
 serde = "0.9"
-bincode = "1.0.0-alpha1"
-
+bincode = "1.0.0-alpha2"

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,4 +1,4 @@
-use bincode::serde::deserialize;
+use bincode::deserialize;
 use serde::Deserialize;
 use std::fs;
 use std::io::{BufReader, ErrorKind, Read, SeekFrom, Seek};
@@ -191,7 +191,7 @@ impl<T> Receiver<T>
 
 #[derive(Debug)]
 pub struct Iter<'a, T: 'a + Deserialize> {
-    rx: &'a mut Receiver<T>
+    rx: &'a mut Receiver<T>,
 }
 
 impl<'a, T> Iterator for Iter<'a, T>
@@ -206,7 +206,7 @@ impl<'a, T> Iterator for Iter<'a, T>
 
 #[derive(Debug)]
 pub struct IntoIter<T: Deserialize> {
-    rx: Receiver<T>
+    rx: Receiver<T>,
 }
 
 impl<T> Iterator for IntoIter<T>

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,5 +1,5 @@
 use bincode::SizeLimit;
-use bincode::serde::serialize_into;
+use bincode::serialize_into;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{Write, BufWriter};


### PR DESCRIPTION
This commit updates hopper to make use of bincode 1.0.0-alpha2. This
removes reliance on the private serde module.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>