### PR TITLE
Bump bincode dep to -alpha6, add fuzz tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ tempdir = "0.3"
 
 [dependencies]
 serde = "0.9"
-bincode = "1.0.0-alpha2"
+bincode = "1.0.0-alpha6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM clux/muslrust:nightly
+
+RUN cargo install cargo-fuzz 
+
+ENV PATH=$PATH:/root/.cargo/bin

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ allocating unbounded amounts of memory or dropping inputs on the floor.
 
 Include the hopper library in your Cargo.toml
 
-`hopper = "0.1"` 
+`hopper = "0.2"` 
 
 and use it in much the same way you'd use stdlib's mpsc:
 
@@ -64,7 +64,7 @@ The on-disk structure look like so:
     
 ```text
 data-dir/
-   sink-name0/
+sink-name0/
       0
       1
    sink-name1/

--- a/benches/mpsc_snd_rcv.rs
+++ b/benches/mpsc_snd_rcv.rs
@@ -10,10 +10,8 @@ use self::test::Bencher;
 fn bench_snd(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
-    b.iter(|| {
-        for _ in 0..10_000 {
-            snd.send(412u64);
-        }
+    b.iter(|| for _ in 0..10_000 {
+        snd.send(412u64);
     });
 }
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+
+[package]
+name = "hopper-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+tempdir = "0.3"
+
+[dependencies.hopper]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "basic_fuzz"
+path = "fuzzers/basic_fuzz.rs"

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,10 @@
+Hopper fuzz tests, using [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
+
+If you'd like to run the tests please go back up to the top-level directory and
+do the following:
+
+    > docker build -t hopper-img . 
+    > docker run  -v $(pwd):/source -w /source -it hopper-img /bin/bash
+    > root@65d32c765696:/source# cargo fuzz run basic_fuzz
+
+The `basic_fuzz` test will run forever. 

--- a/fuzz/fuzzers/basic_fuzz.rs
+++ b/fuzz/fuzzers/basic_fuzz.rs
@@ -1,0 +1,41 @@
+#![no_main]
+#[macro_use]
+extern crate libfuzzer_sys;
+extern crate hopper;
+extern crate tempdir;
+
+use std::str;
+use std::str::FromStr;
+
+fuzz_target!(|data: &[u8]| {
+    let dir = tempdir::TempDir::new("hopper").unwrap();
+    let (mut snd, mut rcv) = hopper::channel("fizzy_lifting", dir.path()).unwrap();
+
+    match str::from_utf8(data) {
+        Ok(st) => {
+            let lines = st.lines();
+            for line in lines {
+                let fields: Vec<u64> = line.split_whitespace()
+                    .map(|f| u64::from_str(f))
+                    .filter(|f| f.is_ok())
+                    .map(|f| f.expect("could not convert to u64"))
+                    .collect();
+
+                if !fields.is_empty() {
+                    let tot = fields[0];
+
+                    for idx in 0..tot {
+                        snd.send(idx);
+                    }
+                    loop {
+                        if !rcv.iter().next().is_some() {
+                            break;
+                        }
+                    }
+
+                }
+            }
+        }
+        Err(_) => {}
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,12 +382,10 @@ mod test {
 
             // start our receiver thread
             let total_pylds = evs.len() * max_thrs;
-            joins.push(thread::spawn(move || {
-                for _ in 0..total_pylds {
-                    loop {
-                        if let Some(_) = rcv.iter().next() {
-                            break;
-                        }
+            joins.push(thread::spawn(move || for _ in 0..total_pylds {
+                loop {
+                    if let Some(_) = rcv.iter().next() {
+                        break;
                     }
                 }
             }));
@@ -396,10 +394,8 @@ mod test {
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 let thr_evs = evs.clone();
-                joins.push(thread::spawn(move || {
-                    for e in thr_evs {
-                        thr_snd.send(e);
-                    }
+                joins.push(thread::spawn(move || for e in thr_evs {
+                    thr_snd.send(e);
                 }));
             }
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,13 +1,12 @@
-use bincode::SizeLimit;
+use bincode::Infinite;
 use bincode::serialize_into;
+use private;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::fs;
-use std::io::{Write, BufWriter};
+use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use std::fmt;
-
-use private;
 
 #[inline]
 fn u32tou8abe(v: u32) -> [u8; 4] {
@@ -16,7 +15,8 @@ fn u32tou8abe(v: u32) -> [u8; 4] {
 
 #[derive(Debug)]
 /// The 'send' side of hopper, similar to
-/// [`std::sync::mpsc::Sender`](https://doc.rust-lang.org/std/sync/mpsc/struct.Sender.html).
+/// [`std::sync::mpsc::Sender`](https://doc.rust-lang.org/std/sync/mpsc/struct.
+/// Sender.html).
 pub struct Sender<T> {
     name: String,
     root: PathBuf, // directory we store our queues in
@@ -110,8 +110,7 @@ impl<T> Sender<T>
             if fslock.disk_buffer.len() >= fslock.in_memory_idx {
                 while let Some(ev) = fslock.disk_buffer.pop_front() {
                     let mut pyld = Vec::with_capacity(64);
-                    serialize_into(&mut pyld, &ev, SizeLimit::Infinite)
-                        .expect("could not serialize");
+                    serialize_into(&mut pyld, &ev, Infinite).expect("could not serialize");
                     // NOTE The conversion of t.len to u32 and usize is _only_
                     // safe when u32 <= usize. That's very likely to hold true
                     // for machines--for now?--that cernan will run on. However!

--- a/tests/afl_crashes.rs
+++ b/tests/afl_crashes.rs
@@ -68,10 +68,8 @@ mod integration {
             // start all our sender threads and blast away
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
-                joins.push(thread::spawn(move || {
-                    for i in 0..cap {
-                        thr_snd.send(i);
-                    }
+                joins.push(thread::spawn(move || for i in 0..cap {
+                    thr_snd.send(i);
                 }));
             }
 


### PR DESCRIPTION
The API for bincode changed between alpha2 and alpha6, causing
build failures for any system that depends on hopper and does a
'cargo update'. Hopper now uses the latest bincode and we verify
that these changes don't cause heartache by porting the old AFL
tests to cargo-fuzz. Instructions for fiddling with the docker
container to run these tests are in fuzz/README

Signed-off-by: Brian L. Troutwine <blt@postmates.com>