### PR TITLE
Upgrade to Bincode 0.8.0, Serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ license = "MIT"
 name = "hopper"
 readme = "README.md"
 repository = "https://github.com/postmates/hopper"
-version = "0.2.2"
+version = "0.3.0"
 
 [dev-dependencies]
 quickcheck = "0.4"
 tempdir = "0.3"
 
 [dependencies]
-serde = "0.9"
-bincode = "1.0.0-alpha6"
+bincode = "0.8.0"
+serde = "1.0"

--- a/benches/mpsc_snd_rcv.rs
+++ b/benches/mpsc_snd_rcv.rs
@@ -11,8 +11,8 @@ fn bench_snd(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| for _ in 0..10_000 {
-        snd.send(412u64);
-    });
+               snd.send(412u64);
+           });
 }
 
 #[bench]
@@ -20,9 +20,9 @@ fn bench_snd_rcv(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-        snd.send(12u64);
-        rcv.iter().next().unwrap();
-    });
+               snd.send(12u64);
+               rcv.iter().next().unwrap();
+           });
 }
 
 #[bench]
@@ -30,11 +30,11 @@ fn bench_all_snd_all_rcv(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-        for _ in 0..10_000 {
-            snd.send(89u64);
-        }
-        for _ in 0..10_000 {
-            rcv.iter().next().unwrap();
-        }
-    });
+               for _ in 0..10_000 {
+                   snd.send(89u64);
+               }
+               for _ in 0..10_000 {
+                   rcv.iter().next().unwrap();
+               }
+           });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,8 @@ mod private;
 pub use self::receiver::Receiver;
 pub use self::sender::Sender;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fs;
 use std::path::Path;
 use std::sync;
@@ -132,7 +133,7 @@ pub enum Error {
 /// assert_eq!(Some(9), rcv.iter().next());
 /// ```
 pub fn channel<T>(name: &str, data_dir: &Path) -> Result<(Sender<T>, Receiver<T>), Error>
-    where T: Serialize + Deserialize
+    where T: Serialize + DeserializeOwned
 {
     channel_with_max_bytes(name, data_dir, 1_048_576 * 100)
 }
@@ -150,7 +151,7 @@ pub fn channel_with_max_bytes<T>(name: &str,
                                  data_dir: &Path,
                                  max_bytes: usize)
                                  -> Result<(Sender<T>, Receiver<T>), Error>
-    where T: Serialize + Deserialize
+    where T: Serialize + DeserializeOwned
 {
     let root = data_dir.join(name);
     let snd_root = root.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ mod test {
         let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
                                                     dir.path(),
                                                     max_bytes)
-            .unwrap();
+                .unwrap();
         let max_thrs = 32;
         let max_sz = 1000;
 
@@ -339,7 +339,9 @@ mod test {
             for _ in 0..(max_sz * max_thrs) {
                 loop {
                     if let Some(nxt) = rcv.iter().next() {
-                        let idx = tst_pylds.binary_search(&nxt).expect("DID NOT FIND ELEMENT");
+                        let idx = tst_pylds
+                            .binary_search(&nxt)
+                            .expect("DID NOT FIND ELEMENT");
                         tst_pylds.remove(idx);
                         break;
                     }
@@ -352,11 +354,11 @@ mod test {
         for i in 0..max_thrs {
             let mut thr_snd = snd.clone();
             joins.push(thread::spawn(move || {
-                let base = i * max_sz;
-                for p in 0..max_sz {
-                    thr_snd.send(base + p);
-                }
-            }));
+                                         let base = i * max_sz;
+                                         for p in 0..max_sz {
+                                             thr_snd.send(base + p);
+                                         }
+                                     }));
         }
 
         // wait until the senders are for sure done
@@ -374,7 +376,7 @@ mod test {
             let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
                                                         dir.path(),
                                                         max_bytes)
-                .unwrap();
+                    .unwrap();
 
             let max_thrs = 32;
 
@@ -383,20 +385,20 @@ mod test {
             // start our receiver thread
             let total_pylds = evs.len() * max_thrs;
             joins.push(thread::spawn(move || for _ in 0..total_pylds {
-                loop {
-                    if let Some(_) = rcv.iter().next() {
-                        break;
-                    }
-                }
-            }));
+                                         loop {
+                                             if let Some(_) = rcv.iter().next() {
+                                                 break;
+                                             }
+                                         }
+                                     }));
 
             // start all our sender threads and blast away
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 let thr_evs = evs.clone();
                 joins.push(thread::spawn(move || for e in thr_evs {
-                    thr_snd.send(e);
-                }));
+                                             thr_snd.send(e);
+                                         }));
             }
 
             // wait until the senders are for sure done

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -202,7 +202,7 @@ impl<T> Receiver<T>
     /// An iterator over messages on a receiver, this iterator will block
     /// whenever `next` is called, waiting for a new message, and `None` will be
     /// returned when the corresponding channel has hung up.
-    pub fn iter<'a>(&'a mut self) -> Iter<'a, T> {
+    pub fn iter(&mut self) -> Iter<T> {
         Iter { rx: self }
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -36,7 +36,7 @@ impl<T> Clone for Sender<T>
                     &self.root,
                     self.max_bytes,
                     self.fs_lock.clone())
-            .unwrap()
+                .unwrap()
     }
 }
 
@@ -57,38 +57,38 @@ impl<T> Sender<T>
             return Err(super::Error::NoSuchDirectory);
         }
         let seq_num = match fs::read_dir(data_dir)
-            .unwrap()
-            .map(|de| {
-                de.unwrap()
-                    .path()
-                    .file_name()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-                    .parse::<usize>()
-                    .unwrap()
-            })
-            .max() {
+                  .unwrap()
+                  .map(|de| {
+            de.unwrap()
+                .path()
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .parse::<usize>()
+                .unwrap()
+        })
+                  .max() {
             Some(sn) => sn,
             None => 0,
         };
         let log = data_dir.join(format!("{}", seq_num));
         match fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&log) {
+                  .append(true)
+                  .create(true)
+                  .open(&log) {
             Ok(fp) => {
                 (*syn).sender_seq_num = seq_num;
                 Ok(Sender {
-                    name: name.into(),
-                    root: data_dir.to_path_buf(),
-                    path: log,
-                    fp: BufWriter::new(fp),
-                    seq_num: seq_num,
-                    max_bytes: max_bytes,
-                    fs_lock: fs_lock,
-                    resource_type: PhantomData,
-                })
+                       name: name.into(),
+                       root: data_dir.to_path_buf(),
+                       path: log,
+                       fp: BufWriter::new(fp),
+                       seq_num: seq_num,
+                       max_bytes: max_bytes,
+                       fs_lock: fs_lock,
+                       resource_type: PhantomData,
+                   })
             }
             Err(e) => panic!("[Sender] failed to start {:?}", e),
         }
@@ -134,11 +134,14 @@ impl<T> Sender<T>
                         // read-only--there's some possibility that this will be
                         // done redundantly, but that's okay--and then read the
                         // current sender_seq_num to get up to date.
-                        let _ = fs::metadata(&self.path).map(|p| {
-                            let mut permissions = p.permissions();
-                            permissions.set_readonly(true);
-                            let _ = fs::set_permissions(&self.path, permissions);
-                        });
+                        let _ =
+                            fs::metadata(&self.path).map(|p| {
+                                                             let mut permissions = p.permissions();
+                                                             permissions.set_readonly(true);
+                                                             let _ =
+                                                                 fs::set_permissions(&self.path,
+                                                                                     permissions);
+                                                         });
                         if self.seq_num != fslock.sender_seq_num {
                             // This thread is behind the leader. We've got to
                             // set our current notion of seq_num forward and
@@ -154,7 +157,10 @@ impl<T> Sender<T>
                             fslock.bytes_written = 0;
                         }
                         self.path = self.root.join(format!("{}", self.seq_num));
-                        match fs::OpenOptions::new().append(true).create(true).open(&self.path) {
+                        match fs::OpenOptions::new()
+                                  .append(true)
+                                  .create(true)
+                                  .open(&self.path) {
                             Ok(fp) => self.fp = BufWriter::new(fp),
                             Err(e) => panic!("FAILED TO OPEN {:?} WITH {:?}", &self.path, e),
                         }
@@ -177,7 +183,9 @@ impl<T> Sender<T>
             fslock.write_bounds[0].1 = fslock.sender_idx;
         } else {
             fslock.sender_captured_recv_id = fslock.receiver_read_id;
-            fslock.write_bounds.push_front((fslock.sender_idx, fslock.sender_idx));
+            fslock
+                .write_bounds
+                .push_front((fslock.sender_idx, fslock.sender_idx));
             fslock.sender_idx += 1;
         }
     }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -28,8 +28,8 @@ pub struct Sender<T> {
     resource_type: PhantomData<T>,
 }
 
-impl<T> Clone for Sender<T>
-    where T: Serialize + Deserialize
+impl<'de, T> Clone for Sender<T>
+    where T: Serialize + Deserialize<'de>
 {
     fn clone(&self) -> Sender<T> {
         Sender::new(self.name.clone(),
@@ -134,14 +134,14 @@ impl<T> Sender<T>
                         // read-only--there's some possibility that this will be
                         // done redundantly, but that's okay--and then read the
                         // current sender_seq_num to get up to date.
-                        let _ =
-                            fs::metadata(&self.path).map(|p| {
-                                                             let mut permissions = p.permissions();
-                                                             permissions.set_readonly(true);
-                                                             let _ =
+                        let _ = fs::metadata(&self.path).map(|p| {
+                                                                 let mut permissions =
+                                                                     p.permissions();
+                                                                 permissions.set_readonly(true);
+                                                                 let _ =
                                                                  fs::set_permissions(&self.path,
                                                                                      permissions);
-                                                         });
+                                                             });
                         if self.seq_num != fslock.sender_seq_num {
                             // This thread is behind the leader. We've got to
                             // set our current notion of seq_num forward and

--- a/tests/afl_crashes.rs
+++ b/tests/afl_crashes.rs
@@ -51,15 +51,11 @@ mod integration {
                 let dur = time::Duration::from_millis(1);
                 for _ in 0..100 {
                     thread::sleep(dur);
-                    loop {
-                        if let Some(i) = rcv.iter().next() {
-                            count += 1;
-                            if max_thrs == 1 {
-                                assert_eq!(i, nxt);
-                                nxt += 1;
-                            }
-                        } else {
-                            break;
+                    for i in rcv.iter() {
+                        count += 1;
+                        if max_thrs == 1 {
+                            assert_eq!(i, nxt);
+                            nxt += 1;
                         }
                     }
                 }

--- a/tests/afl_crashes.rs
+++ b/tests/afl_crashes.rs
@@ -19,7 +19,8 @@ mod integration {
 
         let mut f = File::open(resource).expect("could not open resource file");
         let mut buffer = String::new();
-        f.read_to_string(&mut buffer).expect("could not read resource file");
+        f.read_to_string(&mut buffer)
+            .expect("could not read resource file");
 
         for s in buffer.lines() {
             println!("{}", s);
@@ -38,7 +39,7 @@ mod integration {
             let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
                                                         dir.path(),
                                                         max_bytes)
-                .unwrap();
+                    .unwrap();
 
             let mut joins = Vec::new();
 
@@ -69,8 +70,8 @@ mod integration {
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 joins.push(thread::spawn(move || for i in 0..cap {
-                    thr_snd.send(i);
-                }));
+                                             thr_snd.send(i);
+                                         }));
             }
 
             // wait until the senders are for sure done

--- a/tests/exact_return.rs
+++ b/tests/exact_return.rs
@@ -42,7 +42,7 @@ mod integration {
             let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
                                                         dir.path(),
                                                         max_bytes)
-                .unwrap();
+                    .unwrap();
 
             let mut joins = Vec::new();
 
@@ -64,8 +64,8 @@ mod integration {
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 joins.push(thread::spawn(move || for i in 0..cap {
-                    thr_snd.send(i);
-                }));
+                                             thr_snd.send(i);
+                                         }));
             }
 
             // wait until the senders are for sure done
@@ -92,7 +92,7 @@ mod integration {
         let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
                                                     dir.path(),
                                                     max_bytes)
-            .unwrap();
+                .unwrap();
 
         let mut joins = Vec::new();
 
@@ -114,8 +114,8 @@ mod integration {
         for _ in 0..max_thrs {
             let mut thr_snd = snd.clone();
             joins.push(thread::spawn(move || for i in 0..cap {
-                thr_snd.send(i);
-            }));
+                                         thr_snd.send(i);
+                                     }));
         }
 
         // wait until the senders are for sure done


### PR DESCRIPTION
This commit bumps the bincode dep to 0.8.0 which brings the dependency on serde up to 1.0. As a result the Deserialize trait we used to use now takes a lifetime. I _think_ we want DeserializeOwned on account of we want to throw the intermediate buffer away, per the justification for DeserializeOwned here: https://serde.rs/lifetimes.html

It is a pain, though, that we're continually constructing that little vector, copying some parts out -- depending on the T -- and tossing the whole thing. But! I guess we can't do much better since we'd need to keep whatever we have resident in place somewhere in memory to satisfy the lifetime of the T.