### PR TITLE
Removed unbounded member of FsLock

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -7,7 +7,7 @@ pub struct FsSync<T> {
     pub receiver_idx: Option<usize>,
     pub receiver_max_idx: Option<usize>,
 
-    pub write_bounds: VecDeque<(usize, usize)>, // yikes, unbounded
+    pub write_bounds: VecDeque<usize>, // yikes, unbounded
     pub writes_to_read: usize,
 
     pub sender_idx: usize,

--- a/src/private.rs
+++ b/src/private.rs
@@ -7,7 +7,7 @@ pub struct FsSync<T> {
     pub receiver_idx: Option<usize>,
     pub receiver_max_idx: Option<usize>,
 
-    pub write_bounds: VecDeque<usize>, // yikes, unbounded
+    pub write_bound: Option<usize>,
     pub writes_to_read: usize,
 
     pub sender_idx: usize,
@@ -28,7 +28,7 @@ impl<T> FsSync<T> {
             receiver_idx: None,
             receiver_max_idx: None,
 
-            write_bounds: VecDeque::with_capacity(128),
+            write_bound: None,
             writes_to_read: 0,
 
             sender_idx: 0,

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -103,8 +103,7 @@ impl<T> Receiver<T>
 
             if fslock.receiver_idx.is_none() {
                 let bnds = fslock.write_bounds.pop_back().expect("NO BOUND");
-                fslock.receiver_idx = Some(bnds.0);
-                fslock.receiver_max_idx = Some(bnds.1);
+                fslock.receiver_idx = Some(bnds);
             }
             if fslock.receiver_idx.unwrap() < fslock.in_memory_idx {
                 let event = fslock

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -102,8 +102,7 @@ impl<T> Receiver<T>
             fslock.receiver_read_id = fslock.receiver_read_id.wrapping_add(1);
 
             if fslock.receiver_idx.is_none() {
-                let bnds = fslock.write_bounds.pop_back().expect("NO BOUND");
-                fslock.receiver_idx = Some(bnds);
+                fslock.receiver_idx = Some(fslock.write_bound.expect("NO BOUND"));
             }
             if fslock.receiver_idx.unwrap() < fslock.in_memory_idx {
                 let event = fslock

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -180,12 +180,11 @@ impl<T> Sender<T>
         if fslock.sender_captured_recv_id == fslock.receiver_read_id &&
            !fslock.write_bounds.is_empty() {
             fslock.sender_idx += 1;
-            fslock.write_bounds[0].1 = fslock.sender_idx;
         } else {
             fslock.sender_captured_recv_id = fslock.receiver_read_id;
             fslock
                 .write_bounds
-                .push_front((fslock.sender_idx, fslock.sender_idx));
+                .push_front(fslock.sender_idx);
             fslock.sender_idx += 1;
         }
     }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -177,16 +177,12 @@ impl<T> Sender<T>
             }
         }
         fslock.writes_to_read += 1;
-        if fslock.sender_captured_recv_id == fslock.receiver_read_id &&
-           !fslock.write_bounds.is_empty() {
-            fslock.sender_idx += 1;
-        } else {
+        if (fslock.sender_captured_recv_id != fslock.receiver_read_id) ||
+            fslock.write_bound.is_none() {
             fslock.sender_captured_recv_id = fslock.receiver_read_id;
-            fslock
-                .write_bounds
-                .push_front(fslock.sender_idx);
-            fslock.sender_idx += 1;
+            fslock.write_bound = Some(fslock.sender_idx);
         }
+        fslock.sender_idx += 1;
     }
 
     /// Return the sender's name


### PR DESCRIPTION
These two commits resolve the issue of unbounded memory growth in cernan. It turns out every messages sent through Sender would cause 128 bytes to be pushed onto an unbounded VecDeque. In a previous life this VecDeque was used for proper coordination between the Senders and its Receiver but the optimization made in #5 broke this need. In doing so, we _also_ broke the emptying of this deque. 

This is now corrected and hopper will use a bounded amount of memory. 