### PR TITLE
Move senders' file descriptor into FsSync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 name = "hopper"
 readme = "README.md"
 repository = "https://github.com/postmates/hopper"
-version = "0.3.1"
+version = "0.3.2"
 
 [dev-dependencies]
 quickcheck = "0.4"

--- a/benches/mpsc_snd_rcv.rs
+++ b/benches/mpsc_snd_rcv.rs
@@ -1,8 +1,8 @@
 #![feature(test)]
 
-extern crate test;
-extern crate tempdir;
 extern crate hopper;
+extern crate tempdir;
+extern crate test;
 
 use self::test::Bencher;
 
@@ -11,8 +11,8 @@ fn bench_snd(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| for _ in 0..10_000 {
-               snd.send(412u64);
-           });
+        snd.send(412u64);
+    });
 }
 
 #[bench]
@@ -20,9 +20,9 @@ fn bench_snd_rcv(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-               snd.send(12u64);
-               rcv.iter().next().unwrap();
-           });
+        snd.send(12u64);
+        rcv.iter().next().unwrap();
+    });
 }
 
 #[bench]
@@ -30,11 +30,11 @@ fn bench_all_snd_all_rcv(b: &mut Bencher) {
     let dir = tempdir::TempDir::new("hopper").unwrap();
     let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
     b.iter(|| {
-               for _ in 0..10_000 {
-                   snd.send(89u64);
-               }
-               for _ in 0..10_000 {
-                   rcv.iter().next().unwrap();
-               }
-           });
+        for _ in 0..10_000 {
+            snd.send(89u64);
+        }
+        for _ in 0..10_000 {
+            rcv.iter().next().unwrap();
+        }
+    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,6 @@
-#![deny(missing_docs,
-        missing_debug_implementations,
-        missing_copy_implementations,
-        trivial_numeric_casts,
-        unsafe_code,
-        unstable_features,
-        unused_import_braces,
-        unused_qualifications)]
+#![deny(missing_docs, missing_debug_implementations, missing_copy_implementations,
+       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+       unused_qualifications)]
 //! hopper - an unbounded mpsc with bounded memory
 //!
 //! This module provides a version of the rust standard
@@ -133,7 +128,8 @@ pub enum Error {
 /// assert_eq!(Some(9), rcv.iter().next());
 /// ```
 pub fn channel<T>(name: &str, data_dir: &Path) -> Result<(Sender<T>, Receiver<T>), Error>
-    where T: Serialize + DeserializeOwned
+where
+    T: Serialize + DeserializeOwned,
 {
     channel_with_max_bytes(name, data_dir, 1_048_576 * 100)
 }
@@ -147,11 +143,13 @@ pub fn channel<T>(name: &str, data_dir: &Path) -> Result<(Sender<T>, Receiver<T>
 /// This function gives control to the user over the maximum size of hopper's
 /// queue files as `max_bytes`, though not the total disk allocation that may be
 /// made.
-pub fn channel_with_max_bytes<T>(name: &str,
-                                 data_dir: &Path,
-                                 max_bytes: usize)
-                                 -> Result<(Sender<T>, Receiver<T>), Error>
-    where T: Serialize + DeserializeOwned
+pub fn channel_with_max_bytes<T>(
+    name: &str,
+    data_dir: &Path,
+    max_bytes: usize,
+) -> Result<(Sender<T>, Receiver<T>), Error>
+where
+    T: Serialize + DeserializeOwned,
 {
     let root = data_dir.join(name);
     let snd_root = root.clone();
@@ -170,8 +168,8 @@ pub fn channel_with_max_bytes<T>(name: &str,
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
     extern crate quickcheck;
+    extern crate tempdir;
 
     use std::thread;
     use super::{channel, channel_with_max_bytes};
@@ -317,10 +315,11 @@ mod test {
         let max_bytes: usize = 512;
         let dir = tempdir::TempDir::new("hopper").unwrap();
         println!("CONCURRENT SND_RECV TESTDIR: {:?}", dir);
-        let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
-                                                    dir.path(),
-                                                    max_bytes)
-                .unwrap();
+        let (snd, mut rcv) = channel_with_max_bytes(
+            "concurrent_snd_and_rcv_small_max_bytes",
+            dir.path(),
+            max_bytes,
+        ).unwrap();
         let max_thrs = 32;
         let max_sz = 1000;
 
@@ -340,9 +339,7 @@ mod test {
             for _ in 0..(max_sz * max_thrs) {
                 loop {
                     if let Some(nxt) = rcv.iter().next() {
-                        let idx = tst_pylds
-                            .binary_search(&nxt)
-                            .expect("DID NOT FIND ELEMENT");
+                        let idx = tst_pylds.binary_search(&nxt).expect("DID NOT FIND ELEMENT");
                         tst_pylds.remove(idx);
                         break;
                     }
@@ -355,11 +352,11 @@ mod test {
         for i in 0..max_thrs {
             let mut thr_snd = snd.clone();
             joins.push(thread::spawn(move || {
-                                         let base = i * max_sz;
-                                         for p in 0..max_sz {
-                                             thr_snd.send(base + p);
-                                         }
-                                     }));
+                let base = i * max_sz;
+                for p in 0..max_sz {
+                    thr_snd.send(base + p);
+                }
+            }));
         }
 
         // wait until the senders are for sure done
@@ -374,10 +371,11 @@ mod test {
             let max_bytes: usize = 512;
             let dir = tempdir::TempDir::new("hopper").unwrap();
             println!("CONCURRENT SND_RECV TESTDIR: {:?}", dir);
-            let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
-                                                        dir.path(),
-                                                        max_bytes)
-                    .unwrap();
+            let (snd, mut rcv) = channel_with_max_bytes(
+                "concurrent_snd_and_rcv_small_max_bytes",
+                dir.path(),
+                max_bytes,
+            ).unwrap();
 
             let max_thrs = 32;
 
@@ -386,20 +384,20 @@ mod test {
             // start our receiver thread
             let total_pylds = evs.len() * max_thrs;
             joins.push(thread::spawn(move || for _ in 0..total_pylds {
-                                         loop {
-                                             if let Some(_) = rcv.iter().next() {
-                                                 break;
-                                             }
-                                         }
-                                     }));
+                loop {
+                    if let Some(_) = rcv.iter().next() {
+                        break;
+                    }
+                }
+            }));
 
             // start all our sender threads and blast away
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 let thr_evs = evs.clone();
                 joins.push(thread::spawn(move || for e in thr_evs {
-                                             thr_snd.send(e);
-                                         }));
+                    thr_snd.send(e);
+                }));
             }
 
             // wait until the senders are for sure done

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use std::io::BufWriter;
+use std::fs;
 
 #[derive(Default, Debug)]
 pub struct FsSync<T> {
@@ -12,6 +14,7 @@ pub struct FsSync<T> {
 
     pub sender_idx: usize,
     pub sender_captured_recv_id: u64,
+    pub sender_fp: Option<BufWriter<fs::File>>,
 
     pub in_memory_idx: usize,
     pub bytes_written: usize,
@@ -33,6 +36,7 @@ impl<T> FsSync<T> {
 
             sender_idx: 0,
             sender_captured_recv_id: 0,
+            sender_fp: None,
 
             in_memory_idx: cap,
             bytes_written: 0,

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -21,7 +21,6 @@ pub struct Sender<T> {
     name: String,
     root: PathBuf, // directory we store our queues in
     path: PathBuf, // active fp filename
-    fp: BufWriter<fs::File>, // active fp
     seq_num: usize,
     max_bytes: usize,
     fs_lock: private::FSLock<T>,
@@ -29,27 +28,32 @@ pub struct Sender<T> {
 }
 
 impl<'de, T> Clone for Sender<T>
-    where T: Serialize + Deserialize<'de>
+where
+    T: Serialize + Deserialize<'de>,
 {
     fn clone(&self) -> Sender<T> {
-        Sender::new(self.name.clone(),
-                    &self.root,
-                    self.max_bytes,
-                    self.fs_lock.clone())
-                .unwrap()
+        Sender::new(
+            self.name.clone(),
+            &self.root,
+            self.max_bytes,
+            self.fs_lock.clone(),
+        ).expect("COULD NOT CLONE")
     }
 }
 
 impl<T> Sender<T>
-    where T: Serialize
+where
+    T: Serialize,
 {
     #[doc(hidden)]
-    pub fn new<S>(name: S,
-                  data_dir: &Path,
-                  max_bytes: usize,
-                  fs_lock: private::FSLock<T>)
-                  -> Result<Sender<T>, super::Error>
-        where S: Into<String> + fmt::Display
+    pub fn new<S>(
+        name: S,
+        data_dir: &Path,
+        max_bytes: usize,
+        fs_lock: private::FSLock<T>,
+    ) -> Result<Sender<T>, super::Error>
+    where
+        S: Into<String> + fmt::Display,
     {
         let init_fs_lock = fs_lock.clone();
         let mut syn = init_fs_lock.lock().expect("Sender fs_lock poisoned");
@@ -57,38 +61,36 @@ impl<T> Sender<T>
             return Err(super::Error::NoSuchDirectory);
         }
         let seq_num = match fs::read_dir(data_dir)
-                  .unwrap()
-                  .map(|de| {
-            de.unwrap()
-                .path()
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .parse::<usize>()
-                .unwrap()
-        })
-                  .max() {
+            .unwrap()
+            .map(|de| {
+                de.unwrap()
+                    .path()
+                    .file_name()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .parse::<usize>()
+                    .unwrap()
+            })
+            .max()
+        {
             Some(sn) => sn,
             None => 0,
         };
         let log = data_dir.join(format!("{}", seq_num));
-        match fs::OpenOptions::new()
-                  .append(true)
-                  .create(true)
-                  .open(&log) {
+        match fs::OpenOptions::new().append(true).create(true).open(&log) {
             Ok(fp) => {
+                syn.sender_fp = Some(BufWriter::new(fp));
                 (*syn).sender_seq_num = seq_num;
                 Ok(Sender {
-                       name: name.into(),
-                       root: data_dir.to_path_buf(),
-                       path: log,
-                       fp: BufWriter::new(fp),
-                       seq_num: seq_num,
-                       max_bytes: max_bytes,
-                       fs_lock: fs_lock,
-                       resource_type: PhantomData,
-                   })
+                    name: name.into(),
+                    root: data_dir.to_path_buf(),
+                    path: log,
+                    seq_num: seq_num,
+                    max_bytes: max_bytes,
+                    fs_lock: fs_lock,
+                    resource_type: PhantomData,
+                })
             }
             Err(e) => panic!("[Sender] failed to start {:?}", e),
         }
@@ -113,7 +115,7 @@ impl<T> Sender<T>
                     serialize_into(&mut pyld, &ev, Infinite).expect("could not serialize");
                     // NOTE The conversion of t.len to u32 and usize is _only_
                     // safe when u32 <= usize. That's very likely to hold true
-                    // for machines--for now?--that cernan will run on. However!
+                    // for machines--for now?--that hopper will run on. However!
                     let pyld_sz_bytes: [u8; 4] = u32tou8abe(pyld.len() as u32);
                     let mut t = vec![0, 0, 0, 0];
                     t[0] = pyld_sz_bytes[3];
@@ -126,7 +128,10 @@ impl<T> Sender<T>
                     // to decide it has hit the end of its log file--and create
                     // a new log file.
                     let bytes_written = fslock.bytes_written + t.len();
-                    if (bytes_written > self.max_bytes) || (self.seq_num != fslock.sender_seq_num) {
+                    if (bytes_written > self.max_bytes) ||
+                        (self.seq_num != fslock.sender_seq_num) ||
+                        fslock.sender_fp.is_none()
+                    {
                         // Once we've gone over the write limit for our current
                         // file or find that we've gotten behind the current
                         // queue file we need to seek forward to find our place
@@ -135,50 +140,56 @@ impl<T> Sender<T>
                         // done redundantly, but that's okay--and then read the
                         // current sender_seq_num to get up to date.
                         let _ = fs::metadata(&self.path).map(|p| {
-                                                                 let mut permissions =
-                                                                     p.permissions();
-                                                                 permissions.set_readonly(true);
-                                                                 let _ =
-                                                                 fs::set_permissions(&self.path,
-                                                                                     permissions);
-                                                             });
-                        if self.seq_num != fslock.sender_seq_num {
-                            // This thread is behind the leader. We've got to
-                            // set our current notion of seq_num forward and
-                            // then open the corresponding file.
-                            self.seq_num = fslock.sender_seq_num;
-                        } else {
-                            // This thread is the leader. We reset the
-                            // sender_seq_num and bytes written and open the
-                            // next queue file. All follower threads will hit
-                            // the branch above this one.
-                            fslock.sender_seq_num = self.seq_num.wrapping_add(1);
-                            self.seq_num = fslock.sender_seq_num;
-                            fslock.bytes_written = 0;
+                            let mut permissions = p.permissions();
+                            permissions.set_readonly(true);
+                            let _ = fs::set_permissions(&self.path, permissions);
+                        });
+                        if fslock.sender_fp.is_some() {
+                            if self.seq_num != fslock.sender_seq_num {
+                                // This thread is behind the leader. We've got to
+                                // set our current notion of seq_num forward and
+                                // then open the corresponding file.
+                                self.seq_num = fslock.sender_seq_num;
+                            } else {
+                                // This thread is the leader. We reset the
+                                // sender_seq_num and bytes written and open the
+                                // next queue file. All follower threads will hit
+                                // the branch above this one.
+                                fslock.sender_seq_num = self.seq_num.wrapping_add(1);
+                                self.seq_num = fslock.sender_seq_num;
+                                fslock.bytes_written = 0;
+                            }
                         }
                         self.path = self.root.join(format!("{}", self.seq_num));
                         match fs::OpenOptions::new()
-                                  .append(true)
-                                  .create(true)
-                                  .open(&self.path) {
-                            Ok(fp) => self.fp = BufWriter::new(fp),
+                            .append(true)
+                            .create(true)
+                            .open(&self.path)
+                        {
+                            Ok(fp) => fslock.sender_fp = Some(BufWriter::new(fp)),
                             Err(e) => panic!("FAILED TO OPEN {:?} WITH {:?}", &self.path, e),
                         }
                     }
 
-                    let fp = &mut self.fp;
-                    match fp.write(&t[..]) {
-                        Ok(written) => fslock.bytes_written += written,
-                        Err(e) => panic!("Write error: {}", e),
+                    assert!(fslock.sender_fp.is_some());
+                    if let Some(ref mut fp) = fslock.sender_fp {
+                        match fp.write(&t[..]) {
+                            Ok(written) => fslock.bytes_written += written,
+                            Err(e) => panic!("Write error: {}", e),
+                        }
+                        fslock.disk_writes_to_read += 1;
                     }
-                    fslock.disk_writes_to_read += 1;
                 }
-                self.fp.flush().expect("unable to flush");
+                assert!(fslock.sender_fp.is_some());
+                if let Some(ref mut fp) = fslock.sender_fp {
+                    fp.flush().expect("unable to flush");
+                }
             }
         }
         fslock.writes_to_read += 1;
         if (fslock.sender_captured_recv_id != fslock.receiver_read_id) ||
-            fslock.write_bound.is_none() {
+            fslock.write_bound.is_none()
+        {
             fslock.sender_captured_recv_id = fslock.receiver_read_id;
             fslock.write_bound = Some(fslock.sender_idx);
         }

--- a/tests/afl_crashes.rs
+++ b/tests/afl_crashes.rs
@@ -1,6 +1,6 @@
 mod integration {
-    extern crate tempdir;
     extern crate hopper;
+    extern crate tempdir;
 
     use self::hopper::channel_with_max_bytes;
     use std::thread;
@@ -36,10 +36,11 @@ mod integration {
             let max_bytes = pyld[2] as usize;
 
             let dir = tempdir::TempDir::new("hopper").unwrap();
-            let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
-                                                        dir.path(),
-                                                        max_bytes)
-                    .unwrap();
+            let (snd, mut rcv) = channel_with_max_bytes(
+                "concurrent_snd_and_rcv_small_max_bytes",
+                dir.path(),
+                max_bytes,
+            ).unwrap();
 
             let mut joins = Vec::new();
 
@@ -66,8 +67,8 @@ mod integration {
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 joins.push(thread::spawn(move || for i in 0..cap {
-                                             thr_snd.send(i);
-                                         }));
+                    thr_snd.send(i);
+                }));
             }
 
             // wait until the senders are for sure done

--- a/tests/exact_return.rs
+++ b/tests/exact_return.rs
@@ -1,7 +1,7 @@
 mod integration {
-    extern crate tempdir;
     extern crate hopper;
     extern crate quickcheck;
+    extern crate tempdir;
 
     use self::hopper::channel_with_max_bytes;
     use std::thread;
@@ -39,10 +39,11 @@ mod integration {
             }
             let dir = tempdir::TempDir::new("hopper").unwrap();
             println!("CONCURRENT SND_RECV TESTDIR: {:?}", dir);
-            let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
-                                                        dir.path(),
-                                                        max_bytes)
-                    .unwrap();
+            let (snd, mut rcv) = channel_with_max_bytes(
+                "concurrent_snd_and_rcv_small_max_bytes",
+                dir.path(),
+                max_bytes,
+            ).unwrap();
 
             let mut joins = Vec::new();
 
@@ -64,8 +65,8 @@ mod integration {
             for _ in 0..max_thrs {
                 let mut thr_snd = snd.clone();
                 joins.push(thread::spawn(move || for i in 0..cap {
-                                             thr_snd.send(i);
-                                         }));
+                    thr_snd.send(i);
+                }));
             }
 
             // wait until the senders are for sure done
@@ -89,10 +90,11 @@ mod integration {
         let max_bytes = 14;
         let dir = tempdir::TempDir::new("hopper").unwrap();
         println!("CONCURRENT SND_RECV TESTDIR: {:?}", dir);
-        let (snd, mut rcv) = channel_with_max_bytes("concurrent_snd_and_rcv_small_max_bytes",
-                                                    dir.path(),
-                                                    max_bytes)
-                .unwrap();
+        let (snd, mut rcv) = channel_with_max_bytes(
+            "concurrent_snd_and_rcv_small_max_bytes",
+            dir.path(),
+            max_bytes,
+        ).unwrap();
 
         let mut joins = Vec::new();
 
@@ -114,8 +116,8 @@ mod integration {
         for _ in 0..max_thrs {
             let mut thr_snd = snd.clone();
             joins.push(thread::spawn(move || for i in 0..cap {
-                                         thr_snd.send(i);
-                                     }));
+                thr_snd.send(i);
+            }));
         }
 
         // wait until the senders are for sure done


### PR DESCRIPTION
This commit moves the Sender file into FsSync, reducing the total
number of file descriptors hopper requires and freeing up disk
space in the event of a slow Sender not replacing its private
file descriptor.

This resolves #16

Signed-off-by: Brian L. Troutwine <blt@postmates.com>