### PR TITLE
Introduce zlo into hopper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ quickcheck = "0.4"
 tempdir = "0.3"
 
 [dependencies]
-bincode = "0.8.0"
+zlo = "0.1"
 serde = "1.0"

--- a/benches/mpsc_snd_rcv.rs
+++ b/benches/mpsc_snd_rcv.rs
@@ -6,35 +6,104 @@ extern crate test;
 
 use self::test::Bencher;
 
-#[bench]
-fn bench_snd(b: &mut Bencher) {
-    let dir = tempdir::TempDir::new("hopper").unwrap();
-    let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
-    b.iter(|| for _ in 0..10_000 {
-        snd.send(412u64);
-    });
+macro_rules! generate_snd {
+    ($t:ty, $fn:ident, $s:expr) => {
+        #[bench]
+        fn $fn(b: &mut Bencher) {
+            let dir = tempdir::TempDir::new("hopper").unwrap();
+            let (mut snd, _) = hopper::channel("bench_snd", dir.path()).unwrap();
+            b.iter(|| for i in 0..$s {
+                snd.send(i as $t);
+            });
+        }
+    }
 }
 
-#[bench]
-fn bench_snd_rcv(b: &mut Bencher) {
-    let dir = tempdir::TempDir::new("hopper").unwrap();
-    let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
-    b.iter(|| {
-        snd.send(12u64);
-        rcv.iter().next().unwrap();
-    });
+macro_rules! generate_snd_rcv {
+    ($t:ty, $fn:ident) => {
+        #[bench]
+        fn $fn(b: &mut Bencher) {
+            let dir = tempdir::TempDir::new("hopper").unwrap();
+            let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
+            b.iter(|| {
+                snd.send(12 as $t);
+                rcv.iter().next().unwrap();
+            });
+        }
+    }
 }
 
-#[bench]
-fn bench_all_snd_all_rcv(b: &mut Bencher) {
-    let dir = tempdir::TempDir::new("hopper").unwrap();
-    let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
-    b.iter(|| {
-        for _ in 0..10_000 {
-            snd.send(89u64);
+macro_rules! generate_snd_all_rcv {
+    ($t:ty, $fn:ident, $s:expr) => {
+        #[bench]
+        fn $fn(b: &mut Bencher) {
+            let dir = tempdir::TempDir::new("hopper").unwrap();
+            let (mut snd, mut rcv) = hopper::channel("bench_snd", dir.path()).unwrap();
+            b.iter(|| {
+                for i in 0..$s {
+                    snd.send(i as $t);
+                }
+                for _ in 0..$s {
+                    rcv.iter().next().unwrap();
+                }
+            });
         }
-        for _ in 0..10_000 {
-            rcv.iter().next().unwrap();
-        }
-    });
+    }
+}
+
+mod u16 {
+    use super::*;
+
+    generate_snd!(u16, snd_100, 100);
+    generate_snd!(u16, snd_1000, 1000);
+    generate_snd!(u16, snd_10000, 10_000);
+    generate_snd!(u16, snd_65535, 65_535);
+
+    generate_snd_rcv!(u16, snd_rcv_100);
+    generate_snd_rcv!(u16, snd_rcv_1000);
+    generate_snd_rcv!(u16, snd_rcv_10000);
+    generate_snd_rcv!(u16, snd_rcv_65535);
+
+    generate_snd_all_rcv!(u16, snd_all_rcv_100, 100);
+    generate_snd_all_rcv!(u16, snd_all_rcv_1000, 1000);
+    generate_snd_all_rcv!(u16, snd_all_rcv_10000, 10_000);
+    generate_snd_all_rcv!(u16, snd_all_rcv_65535, 65_535);
+}
+
+mod u32 {
+    use super::*;
+
+    generate_snd!(u32, snd_100, 100);
+    generate_snd!(u32, snd_1000, 1000);
+    generate_snd!(u32, snd_10000, 10_000);
+    generate_snd!(u32, snd_65535, 65_535);
+
+    generate_snd_rcv!(u32, snd_rcv_100);
+    generate_snd_rcv!(u32, snd_rcv_1000);
+    generate_snd_rcv!(u32, snd_rcv_10000);
+    generate_snd_rcv!(u32, snd_rcv_65535);
+
+    generate_snd_all_rcv!(u32, snd_all_rcv_100, 100);
+    generate_snd_all_rcv!(u32, snd_all_rcv_1000, 1000);
+    generate_snd_all_rcv!(u32, snd_all_rcv_10000, 10_000);
+    generate_snd_all_rcv!(u32, snd_all_rcv_65535, 65_535);
+}
+
+mod u64 {
+    use super::*;
+
+    generate_snd!(u64, snd_100, 100);
+    generate_snd!(u64, snd_1000, 1000);
+    generate_snd!(u64, snd_10000, 10_000);
+    generate_snd!(u64, snd_65535, 65_535);
+
+    generate_snd_rcv!(u64, snd_rcv_100);
+    generate_snd_rcv!(u64, snd_rcv_1000);
+    generate_snd_rcv!(u64, snd_rcv_10000);
+    generate_snd_rcv!(u64, snd_rcv_65535);
+
+    generate_snd_all_rcv!(u64, snd_all_rcv_100, 100);
+    generate_snd_all_rcv!(u64, snd_all_rcv_1000, 1000);
+    generate_snd_all_rcv!(u64, snd_all_rcv_10000, 10_000);
+    generate_snd_all_rcv!(u64, snd_all_rcv_65535, 65_535);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(missing_docs, missing_debug_implementations, missing_copy_implementations,
-       trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
-       unused_qualifications)]
+        trivial_numeric_casts, unsafe_code, unstable_features, unused_import_braces,
+        unused_qualifications)]
 //! hopper - an unbounded mpsc with bounded memory
 //!
 //! This module provides a version of the rust standard
@@ -79,8 +79,8 @@
 //! hopper limits itself to one exclusive Sender or one exclusive Receiver at a
 //! time. This potentially limits the concurrency of mpsc but maintains data
 //! integrity. We are open to improvements in this area.
-extern crate bincode;
 extern crate serde;
+extern crate zlo;
 
 mod receiver;
 mod sender;
@@ -151,6 +151,8 @@ pub fn channel_with_max_bytes<T>(
 where
     T: Serialize + DeserializeOwned,
 {
+    use std::sync::Arc; 
+
     let root = data_dir.join(name);
     let snd_root = root.clone();
     let rcv_root = root.clone();
@@ -161,7 +163,7 @@ where
     let sz = mem::size_of::<T>();
     let max_bytes = if max_bytes < sz { sz } else { max_bytes };
     let fs_lock = sync::Arc::new(sync::Mutex::new(private::FsSync::new(cap)));
-    let sender = try!(Sender::new(name, &snd_root, max_bytes, fs_lock.clone()));
+    let sender = try!(Sender::new(name, &snd_root, max_bytes, Arc::clone(&fs_lock)));
     let receiver = try!(Receiver::new(&rcv_root, fs_lock));
     Ok((sender, receiver))
 }

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,5 +1,4 @@
-use bincode::deserialize;
-
+use zlo::deserialize;
 use private;
 use serde::de::DeserializeOwned;
 use std::fs;
@@ -111,8 +110,8 @@ where
                 fslock.writes_to_read -= 1;
                 fslock.receiver_idx = fslock.receiver_idx.map(|x| x + 1);
                 return Some(event);
-            } else if (fslock.disk_writes_to_read == 0) &&
-                (fslock.receiver_idx.unwrap() >= fslock.in_memory_idx)
+            } else if (fslock.disk_writes_to_read == 0)
+                && (fslock.receiver_idx.unwrap() >= fslock.in_memory_idx)
             {
                 let event = fslock
                     .disk_buffer


### PR DESCRIPTION
This new serializer is a fork of bincode which reduces the size of
the on-disk payloads for us. It looks to be about 50% for the
cernan use-case.

Signed-off-by: Brian L. Troutwine <blt@postmates.com>