### PR TITLE
Improve OSX benchmark performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Brian L. Troutwine <blt@postmates.com>"]
+authors = ["Brian L. Troutwine <blt@postmates.com>", "Brian L. Troutwine <brian@troutwine.us>"]
 description = "an unbounded mpsc with bounded memory"
 license = "MIT"
 name = "hopper"
@@ -7,20 +7,21 @@ readme = "README.md"
 repository = "https://github.com/postmates/hopper"
 homepage = "https://github.com/postmates/hopper"
 documentation = "https://docs.rs/hopper"
-version = "0.4.2"
+version = "0.4.3-pre"
 keywords = ["mpsc", "channel", "message", "bounded-memory"]
 categories = ["asynchronous", "concurrency"]
 
 [dev-dependencies]
 quickcheck = "0.6"
 tempdir = "0.3"
-criterion = "0.2.0"
+criterion = "0.2"
 
 [dependencies]
 bincode = "1.0"
 byteorder = "1.2"
 flate2 = "1.0"
 serde = "1.0"
+parking_lot = "0.6"
 
 [[bench]]
 name = "stdlib_comparison"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,12 @@
-#![deny(missing_docs, missing_debug_implementations, missing_copy_implementations,
-        trivial_numeric_casts, unstable_features, unused_import_braces, unused_qualifications)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    trivial_numeric_casts,
+    unstable_features,
+    unused_import_braces,
+    unused_qualifications
+)]
 //! hopper - an unbounded mpsc with bounded memory
 //!
 //! This module provides a version of the rust standard
@@ -66,20 +73,21 @@
 extern crate bincode;
 extern crate byteorder;
 extern crate flate2;
+extern crate parking_lot;
 extern crate serde;
 
+mod deque;
+mod private;
 mod receiver;
 mod sender;
-mod private;
-mod deque;
 
 pub use self::receiver::Receiver;
 pub use self::sender::Sender;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::{fs, io, mem, sync};
-use std::sync::atomic::AtomicUsize;
+use serde::Serialize;
 use std::path::Path;
+use std::sync::atomic::AtomicUsize;
+use std::{fs, io, mem, sync};
 
 /// Defines the errors that hopper will bubble up
 ///
@@ -473,8 +481,11 @@ mod test {
             vals: Vec<u64>,
         ) -> TestResult {
             let sz = mem::size_of::<u64>();
-            if total_senders == 0 || total_senders > 10 || vals.len() == 0
-                || (vals.len() < total_senders) || (in_memory_bytes / sz) == 0
+            if total_senders == 0
+                || total_senders > 10
+                || vals.len() == 0
+                || (vals.len() < total_senders)
+                || (in_memory_bytes / sz) == 0
                 || (disk_bytes / sz) == 0
             {
                 return TestResult::discard();

--- a/src/receiver.rs
+++ b/src/receiver.rs
@@ -1,14 +1,14 @@
 use bincode::deserialize_from;
-use private;
 use byteorder::{BigEndian, ReadBytesExt};
+use flate2::read::DeflateDecoder;
+use private;
 use serde::de::DeserializeOwned;
-use std::{fs, sync};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::io::{BufReader, ErrorKind, Read, Seek, SeekFrom};
 use std::iter::IntoIterator;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use flate2::read::DeflateDecoder;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{fs, sync};
 
 #[derive(Debug)]
 /// The 'receive' side of hopper, similar to
@@ -49,9 +49,9 @@ where
                             root: data_dir.to_path_buf(),
                             fp: BufReader::new(fp),
                             resource_type: PhantomData,
-                            mem_buffer: mem_buffer,
+                            mem_buffer,
                             disk_writes_to_read: 0,
-                            max_disk_files: max_disk_files,
+                            max_disk_files,
                         })
                     }
                     Err(e) => Err(super::Error::IoError(e)),
@@ -95,7 +95,8 @@ where
                             // on us. We check the metadata condition of the
                             // file and, if we find it read-only, switch on over
                             // to a new log file.
-                            let metadata = self.fp
+                            let metadata = self
+                                .fp
                                 .get_ref()
                                 .metadata()
                                 .expect("could not get metadata at UnexpectedEof");

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,17 +1,18 @@
 use bincode::serialize_into;
 use byteorder::{BigEndian, WriteBytesExt};
+use deque;
+use deque::BackGuardInner;
+use flate2::write::DeflateEncoder;
+use flate2::Compression;
+use parking_lot::MutexGuard;
 use private;
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::sync::{Arc, MutexGuard};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use deque::BackGuardInner;
 use std::io::{BufWriter, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
-use flate2::Compression;
-use flate2::write::DeflateEncoder;
-use deque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 const PAYLOAD_LEN_BYTES: usize = ::std::mem::size_of::<u32>();
 
@@ -82,8 +83,8 @@ where
                         Ok(Sender {
                             name: name.into(),
                             root: data_dir.to_path_buf(),
-                            max_disk_bytes: max_disk_bytes,
-                            mem_buffer: mem_buffer,
+                            max_disk_bytes,
+                            mem_buffer,
                             resource_type: PhantomData,
                             disk_files_capacity: max_disk_files,
                         })


### PR DESCRIPTION
We've known for a while that OSX has a slow mutex implementation.
The hot path of deque includes acquiring at least one mutex, maybe
two when sending. This meant that OSX suffered from very slow
benchmark performance compared to std MPSC, 100ms vs 1.5ms. This
commit introduces parking_lot Mutex/Condvar to close that gap. No
measurement has been done on Linux as of this writing. The benchmarks
have also been fiddled with to improve their output: we can now
compare the throughput of our benchmarks where before we had to
calculate that.

An example:

```
     Running target/release/deps/stdlib_comparison-486ac007903caae5
hopper/all in-memory/HopperInput { in_memory_max: 8192, on_disk_max: 32768, t...
                        time:   [2.3519 ms 2.3955 ms 2.4444 ms]
                        thrpt:  [3.3513 Melem/s 3.4197 Melem/s 3.4831 Melem/s]
                        change: [-1.3650% +0.5431% +2.5115%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
hopper/all in-memory/HopperInput { in_memory_max: 4096, on_disk_max: 32768, t...
                        time:   [2.4669 ms 2.5005 ms 2.5368 ms]
                        thrpt:  [3.2293 Melem/s 3.2761 Melem/s 3.3207 Melem/s]
                        change: [-15.043% -10.065% -5.1173%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

mpsc/all in-memory      time:   [1.3947 ms 1.4059 ms 1.4209 ms]
                        thrpt:  [5.7654 Melem/s 5.8269 Melem/s 5.8738 Melem/s]
                        change: [-2.7682% -0.5352% +1.4363%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) high mild
  12 (12.00%) high severe
```

Linux performance should be checked before merging this PR.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>